### PR TITLE
React.PropTypes -> prop-types

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 
 dist
+node_modules

--- a/README.md
+++ b/README.md
@@ -106,6 +106,9 @@ prop | type | description
 The space scale and number of grid columns can be configured through React context.
 
 ```js
+import PropTypes from 'prop-types'
+import React from 'react'
+
 // Example context configuration
 class App extends React.Component {
   getChildContext () {
@@ -119,7 +122,7 @@ class App extends React.Component {
 }
 
 App.contextTypes = {
-  robox: React.PropTypes.object
+  robox: PropTypes.object
 }
 ```
 

--- a/package.json
+++ b/package.json
@@ -18,6 +18,8 @@
   "author": "Brent Jackson",
   "license": "MIT",
   "dependencies": {
+    "react": "^15.5.4",
+    "react-dom": "^15.5.4",
     "understyle": "^1.2.0"
   },
   "devDependencies": {
@@ -32,6 +34,7 @@
     "react": "^15.2.1",
     "react-addons-test-utils": "^15.2.1",
     "react-dom": "^15.2.1",
+    "react-test-renderer": "^15.5.4",
     "standard": "^7.1.2",
     "webpack": "^1.13.1",
     "webpack-dev-server": "^1.14.1"

--- a/src/Robox.js
+++ b/src/Robox.js
@@ -1,4 +1,5 @@
 
+import PropTypes from 'prop-types'
 import React from 'react'
 import { createUnderstyle } from 'understyle'
 
@@ -64,58 +65,58 @@ const Robox = (Comp) => {
   }
 
   WrappedComponent.contextTypes = {
-    robox: React.PropTypes.shape({
-      scale: React.PropTypes.arrayOf(React.PropTypes.number),
-      columns: React.PropTypes.number
+    robox: PropTypes.shape({
+      scale: PropTypes.arrayOf(PropTypes.number),
+      columns: PropTypes.number
     })
   }
 
   const spaceScale = [ 0, 1, 2, 3, 4, 5, 6 ]
 
   WrappedComponent.propTypes = {
-    m: React.PropTypes.oneOf(spaceScale),
-    mt: React.PropTypes.oneOf(spaceScale),
-    mr: React.PropTypes.oneOf(spaceScale),
-    mb: React.PropTypes.oneOf(spaceScale),
-    ml: React.PropTypes.oneOf(spaceScale),
-    mx: React.PropTypes.oneOf(spaceScale),
-    my: React.PropTypes.oneOf(spaceScale),
-    gutter: React.PropTypes.oneOf(spaceScale),
-    p: React.PropTypes.oneOf(spaceScale),
-    pt: React.PropTypes.oneOf(spaceScale),
-    pr: React.PropTypes.oneOf(spaceScale),
-    pb: React.PropTypes.oneOf(spaceScale),
-    pl: React.PropTypes.oneOf(spaceScale),
-    px: React.PropTypes.oneOf(spaceScale),
-    py: React.PropTypes.oneOf(spaceScale),
-    col: React.PropTypes.number,
-    block: React.PropTypes.bool,
-    inlineBlock: React.PropTypes.bool,
-    inline: React.PropTypes.bool,
-    table: React.PropTypes.bool,
-    tableRow: React.PropTypes.bool,
-    tableCell: React.PropTypes.bool,
-    flex: React.PropTypes.bool,
-    inlineFlex: React.PropTypes.bool,
-    wrap: React.PropTypes.bool,
-    flexColumn: React.PropTypes.bool,
-    align: React.PropTypes.oneOf([
+    m: PropTypes.oneOf(spaceScale),
+    mt: PropTypes.oneOf(spaceScale),
+    mr: PropTypes.oneOf(spaceScale),
+    mb: PropTypes.oneOf(spaceScale),
+    ml: PropTypes.oneOf(spaceScale),
+    mx: PropTypes.oneOf(spaceScale),
+    my: PropTypes.oneOf(spaceScale),
+    gutter: PropTypes.oneOf(spaceScale),
+    p: PropTypes.oneOf(spaceScale),
+    pt: PropTypes.oneOf(spaceScale),
+    pr: PropTypes.oneOf(spaceScale),
+    pb: PropTypes.oneOf(spaceScale),
+    pl: PropTypes.oneOf(spaceScale),
+    px: PropTypes.oneOf(spaceScale),
+    py: PropTypes.oneOf(spaceScale),
+    col: PropTypes.number,
+    block: PropTypes.bool,
+    inlineBlock: PropTypes.bool,
+    inline: PropTypes.bool,
+    table: PropTypes.bool,
+    tableRow: PropTypes.bool,
+    tableCell: PropTypes.bool,
+    flex: PropTypes.bool,
+    inlineFlex: PropTypes.bool,
+    wrap: PropTypes.bool,
+    flexColumn: PropTypes.bool,
+    align: PropTypes.oneOf([
       'flex-start',
       'flex-end',
       'baseline',
       'center',
       'stretch'
     ]),
-    justify: React.PropTypes.oneOf([
+    justify: PropTypes.oneOf([
       'flex-start',
       'flex-end',
       'space-between',
       'space-around',
       'center'
     ]),
-    flexAuto: React.PropTypes.bool,
-    flexNone: React.PropTypes.bool,
-    order: React.PropTypes.number,
+    flexAuto: PropTypes.bool,
+    flexNone: PropTypes.bool,
+    order: PropTypes.number,
 
     // Warn against legacy prop name
     column: (props, propName, componentName) => {


### PR DESCRIPTION
v15.5.0 of react adds a [deprecation warning for `React.PropTypes`](https://facebook.github.io/react/blog/#migrating-from-react.proptypes).

Instead we're encouraged to install the separate `prop-types` package and use PropTypes from there.

```js
import PropTypes from 'prop-types';
```

This PR adds upgrades the version of react in the `devDependencies`, adds `prop-types` to the deps, and updates all components to use the `prop-types` package instead of `React.PropTypes`.